### PR TITLE
added two new learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ This repository helps developers, architects, and security engineers:
 ## 🌐 Identity Communities & Conferences
 
 - [Identiverse](https://identiverse.com/)
+- [AuthCon](https://www.authcon.io/)
 - [IDPro](https://idpro.org/)
 - [LinkedIn Group](https://www.linkedin.com/groups/8555929/)
 - [KuppingerCole Events](https://www.kuppingercole.com/events)
@@ -193,6 +194,7 @@ This repository helps developers, architects, and security engineers:
 - CIAM for Startups vs Enterprises
 - Build-Your-Own CIAM Blueprint (Coming Soon)
 - CIAM Security Design Patterns (Coming Soon)
+- [Auth Omnibus](https://authomnibus.com/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ This repository helps developers, architects, and security engineers:
 - [FusionAuth Expert Advice](https://fusionauth.io/learn/expert-advice/)
 - [IDPro Body of Knowledge](https://bok.idpro.org/)
 - [OpenID Foundation Workshops](https://openid.net/foundation/)
+- [CIAM Weekly Newsletter](http://ciamweekly.com/)
+- [IDPRO Body of Knowledge](https://bok.idpro.org/articles/)
 
 ---
 


### PR DESCRIPTION
This PR includes two new learning resources, a conference and a link to a decision framework

* a newsletter about CIAM (that I write)
* a link to the IDPRO body of knowledge (which includes CIAM and other identity articles)
* authcon (a CIAM conference)
* the auth omnibus (a decision site)